### PR TITLE
On demand reactify

### DIFF
--- a/Demo/MTRAppDelegate.m
+++ b/Demo/MTRAppDelegate.m
@@ -7,11 +7,14 @@
 //
 
 #import "MTRAppDelegate.h"
+#import "MTRReactiveEngine.h"
 
 @implementation MTRAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+    [MTRReactiveEngine engage];
+    
     return YES;
 }
 

--- a/Demo/MTRAppDelegate.m
+++ b/Demo/MTRAppDelegate.m
@@ -7,13 +7,13 @@
 //
 
 #import "MTRAppDelegate.h"
-#import "MTRReactiveEngine.h"
+#import "MTRReactor.h"
 
 @implementation MTRAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    [MTRReactiveEngine engage];
+    [MTRReactor engage];
     
     return YES;
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ If you want to whitelist/blacklist certain properties, you can implement *either
 There are a few caveats to keep in mind:
 - Just because your superclass adopts `MTRReactive` doesn't mean your properties are also reactive. Every class that wants reactivity must adopt the protocol independently.
 - Properties which don't have a setter won't be reactive, as there's no way to invalidate its dependency.
+- You'll need to register classes conforming to `MTRReactive`, and there are two ways of doing that:
+    1. Automatically, sending a message to `[MTRReactiveEngine engage]`.
+    You can do that, for example, on `- (BOOL)applicationDidFinishLaunching:`.
+    
+    2. On-demand, sending a message to `[MTRReactiveEngine reactify:self.class]`.
+    You can override `+ (void)initialize` and add that message.
 
 You can then react to your objects' properties in computations like normal:
 ```Objective-C

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ There are a few caveats to keep in mind:
 - Just because your superclass adopts `MTRReactive` doesn't mean your properties are also reactive. Every class that wants reactivity must adopt the protocol independently.
 - Properties which don't have a setter won't be reactive, as there's no way to invalidate its dependency.
 - You'll need to register classes conforming to `MTRReactive`, and there are two ways of doing that:
-    1. Automatically, sending a message to `[MTRReactiveEngine engage]`.
+    1. Automatically, sending a message to `[MTRReactor engage]`.
     You can do that, for example, on `- (BOOL)applicationDidFinishLaunching:`.
     
-    2. On-demand, sending a message to `[MTRReactiveEngine reactify:self.class]`.
+    2. On-demand, sending a message to `[MTRReactor reactify:self.class]`.
     You can override `+ (void)initialize` and add that message.
 
 You can then react to your objects' properties in computations like normal:

--- a/Reactor/MTRReactiveEngine.h
+++ b/Reactor/MTRReactiveEngine.h
@@ -8,6 +8,7 @@
 
 @import Foundation;
 
+@protocol MTRReactive;
 @interface MTRReactiveEngine : NSObject
 
 /**
@@ -18,5 +19,13 @@
 */
 
 + (void)engage;
+
+/**
+ @brief Manually adds reactivity to marked classes
+ 
+ Use this method if you want to have on-demand reactification.
+ */
+
++ (void)reactify:(Class<MTRReactive>)klass;
 
 @end

--- a/Reactor/MTRReactor.h
+++ b/Reactor/MTRReactor.h
@@ -8,6 +8,7 @@
 
 #import "MTRComputation.h"
 
+@protocol MTRReactive;
 @interface MTRReactor : NSObject
 
 /**
@@ -28,6 +29,23 @@
 */
 
 @property (nonatomic, readonly) MTRComputation *currentComputation;
+
+/**
+ @brief Adds reactivity to marked classes
+ 
+ Sweeps the class list for classes adopting @c MTRReactive, and swizzles their
+ property setters/getters to add reactivity.
+ */
+
++ (void)engage;
+
+/**
+ @brief Manually adds reactivity to marked classes
+ 
+ Use this method if you want to have on-demand reactification.
+ */
+
++ (void)reactify:(Class<MTRReactive>)klass;
 
 /**
  @brief Starts a new computation with the given block

--- a/Reactor/MTRReactor.m
+++ b/Reactor/MTRReactor.m
@@ -25,8 +25,6 @@
 
 - (instancetype)init
 {
-    [MTRReactiveEngine engage];
-    
     if(self = [super init]) {
         _pendingComputations = [NSMutableArray new];
         _afterFlushHandlers  = [NSMutableArray new];

--- a/Reactor/MTRReactor.m
+++ b/Reactor/MTRReactor.m
@@ -34,6 +34,18 @@
     return self;
 }
 
+# pragma mark - Registration
+
++ (void)engage
+{
+    [MTRReactiveEngine engage];
+}
+
++ (void)reactify:(Class<MTRReactive>)klass
+{
+    [MTRReactiveEngine reactify:klass];
+}
+
 # pragma mark - Execution
 
 + (MTRComputation *)autorun:(void (^)(MTRComputation *))block


### PR DESCRIPTION
It turns out that automatically sending a message to `[MTRReactiveEngine engage]` is not scaling well.
In the project that I'm currently working on, it was taking 5 seconds to iterate through all the classes.
My suggestion is to let consumers engage it automatically or on-demand.
More details on `README.md`

This breaks compatibility, so I think would be nice to bump major.

Thanks @wzrad!